### PR TITLE
Change URL for Moodle Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ The plugin uses Moodle core's analytics API as a base. This predictive model ind
 
 # Installation
 
-https://docs.moodle.org/35/en/Installing_plugins
+https://docs.moodle.org/en/Installing_plugins
 
 # Usage
 
-https://docs.moodle.org/35/en/Analytics
+https://docs.moodle.org/en/Analytics
 
 # Known bugs
 


### PR DESCRIPTION
If you remove the Moodle branch number for the Moodle Docs URL, you will be taken to the newest branch version of Moodle Docs. No need to update the URL every 6 months :)